### PR TITLE
chore: remove swift.bzl umbrella loads

### DIFF
--- a/bzlmod/workspace/Sources/MyExecutable/BUILD.bazel
+++ b/bzlmod/workspace/Sources/MyExecutable/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+load("@build_bazel_rules_swift//swift:swift_binary.bzl", "swift_binary")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 swift_binary(

--- a/bzlmod/workspace/Sources/MyLibrary/BUILD.bazel
+++ b/bzlmod/workspace/Sources/MyLibrary/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 swift_library(

--- a/bzlmod/workspace/Sources/System/BUILD.bazel
+++ b/bzlmod/workspace/Sources/System/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
 
 swift_library(
     name = "System",

--- a/bzlmod/workspace/Tests/MyLibraryTests/BUILD.bazel
+++ b/bzlmod/workspace/Tests/MyLibraryTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+load("@build_bazel_rules_swift//swift:swift_test.bzl", "swift_test")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 swift_test(

--- a/examples/grpc_example/sources/client/BUILD.bazel
+++ b/examples/grpc_example/sources/client/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swift//swift:swift.bzl", "swift_binary")
+load("@rules_swift//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "client",

--- a/examples/grpc_example/sources/server/BUILD.bazel
+++ b/examples/grpc_example/sources/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swift//swift:swift.bzl", "swift_binary")
+load("@rules_swift//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "server",

--- a/examples/grpc_example/sources/test/BUILD.bazel
+++ b/examples/grpc_example/sources/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swift//swift:swift.bzl", "swift_test")
+load("@rules_swift//swift:swift_test.bzl", "swift_test")
 
 swift_test(
     name = "test",

--- a/examples/grpc_package_example/sources/client/BUILD.bazel
+++ b/examples/grpc_package_example/sources/client/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swift//swift:swift.bzl", "swift_binary")
+load("@rules_swift//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "client",

--- a/examples/grpc_package_example/sources/server/BUILD.bazel
+++ b/examples/grpc_package_example/sources/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swift//swift:swift.bzl", "swift_binary")
+load("@rules_swift//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "server",

--- a/examples/grpc_package_example/sources/test/BUILD.bazel
+++ b/examples/grpc_package_example/sources/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swift//swift:swift.bzl", "swift_test")
+load("@rules_swift//swift:swift_test.bzl", "swift_test")
 
 swift_test(
     name = "test",

--- a/examples/simple/Sources/MyExecutable/BUILD.bazel
+++ b/examples/simple/Sources/MyExecutable/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+load("@build_bazel_rules_swift//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "MyExecutable",

--- a/examples/simple/Sources/MyLibrary/BUILD.bazel
+++ b/examples/simple/Sources/MyLibrary/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
 
 swift_library(
     name = "MyLibrary",

--- a/examples/simple/Tests/MyLibraryTests/BUILD.bazel
+++ b/examples/simple/Tests/MyLibraryTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+load("@build_bazel_rules_swift//swift:swift_test.bzl", "swift_test")
 
 swift_test(
     name = "MyLibraryTests",

--- a/gazelle/internal/swift/http_archive_test.go
+++ b/gazelle/internal/swift/http_archive_test.go
@@ -93,7 +93,7 @@ http_archive(
 http_archive(
     name = "com_github_apple_swift_collections",
     build_file_content = """\
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
 swift_library(
     name = "Collections",
     srcs = glob(["Sources/Collections/**/*.swift"]),
@@ -118,7 +118,7 @@ swift_library(
 http_archive(
     name = "com_github_apple_swift_argument_parser",
     build_file_content = """\
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
 swift_library(
     name = "ArgumentParser",
     srcs = glob(["Sources/ArgumentParser/**/*.swift"]),

--- a/gazelle/lang.go
+++ b/gazelle/lang.go
@@ -36,10 +36,20 @@ func (*swiftLang) ApparentLoads(moduleToApparentName func(string) string) []rule
 	}
 	return []rule.LoadInfo{
 		{
-			Name: fmt.Sprintf("@%s//swift:swift.bzl", rulesSwift),
+			Name: fmt.Sprintf("@%s//swift:%s.bzl", rulesSwift, swift.BinaryRuleKind),
+			Symbols: []string{
+				swift.BinaryRuleKind,
+			},
+		},
+		{
+			Name: fmt.Sprintf("@%s//swift:%s.bzl", rulesSwift, swift.LibraryRuleKind),
 			Symbols: []string{
 				swift.LibraryRuleKind,
-				swift.BinaryRuleKind,
+			},
+		},
+		{
+			Name: fmt.Sprintf("@%s//swift:%s.bzl", rulesSwift, swift.TestRuleKind),
+			Symbols: []string{
 				swift.TestRuleKind,
 			},
 		},


### PR DESCRIPTION
Remove `swift.bzl` umbrella loads in favor of granular loads