### PR TITLE
chore: upgrade MacOS runner to macos-15

### DIFF
--- a/.github/actions/set_up_macos/action.yml
+++ b/.github/actions/set_up_macos/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.2'
+        xcode-version: '16.3'
     - name: Confirm Xcode Version
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,43 +34,43 @@ jobs:
           - test: '@@//bzlmod:e2e_test'
             runner: ubuntu-22.04
           - test: '@@//bzlmod:e2e_test'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:custom_swift_proto_compiler_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:custom_swift_proto_compiler_test_bazel_.bazelversion'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:custom_swift_proto_compiler_test_bazel_last_green'
             runner: ubuntu-22.04
           - test: '@@//examples:custom_swift_proto_compiler_test_bazel_last_green'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:grpc_example_test_bazel_last_green'
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_example_test_bazel_last_green'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:grpc_package_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_package_example_test_bazel_.bazelversion'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:grpc_package_example_test_bazel_last_green'
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_package_example_test_bazel_last_green'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:simple_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:simple_test_bazel_.bazelversion'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//examples:simple_test_bazel_last_green'
             runner: ubuntu-22.04
           - test: '@@//examples:simple_test_bazel_last_green'
-            runner: macos-14
+            runner: macos-15
           - test: '@@//release:archive_test'
             runner: ubuntu-22.04
           - test: '@@//release:archive_test'
-            runner: macos-14
+            runner: macos-15
     runs-on: ${{ matrix.runner }}
     env:
       CC: clang
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - macos-14
+          - macos-15
           - ubuntu-22.04
     runs-on: ${{ matrix.runner }}
     env:

--- a/tools/generate_ci_workflow/internal/testparams/int_test_params.go
+++ b/tools/generate_ci_workflow/internal/testparams/int_test_params.go
@@ -13,7 +13,7 @@ type IntTestParams struct {
 func (itp *IntTestParams) Runner() string {
 	switch itp.OS {
 	case MacOS:
-		return "macos-14"
+		return "macos-15"
 	case LinuxOS:
 		return "ubuntu-22.04"
 	default:


### PR DESCRIPTION
The Renovate bot is using Swift 6.x. Upgrade the runners in this repo so that the tooling does not fail as is happening in #67.