### PR TITLE
chore: enables last_green builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,33 @@ jobs:
             runner: ubuntu-22.04
           - test: '@@//examples:custom_swift_proto_compiler_test_bazel_.bazelversion'
             runner: macos-15
+          - test: '@@//examples:custom_swift_proto_compiler_test_bazel_last_green'
+            runner: ubuntu-22.04
+          - test: '@@//examples:custom_swift_proto_compiler_test_bazel_last_green'
+            runner: macos-15
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
+            runner: macos-15
+          - test: '@@//examples:grpc_example_test_bazel_last_green'
+            runner: ubuntu-22.04
+          - test: '@@//examples:grpc_example_test_bazel_last_green'
             runner: macos-15
           - test: '@@//examples:grpc_package_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_package_example_test_bazel_.bazelversion'
             runner: macos-15
+          - test: '@@//examples:grpc_package_example_test_bazel_last_green'
+            runner: ubuntu-22.04
+          - test: '@@//examples:grpc_package_example_test_bazel_last_green'
+            runner: macos-15
           - test: '@@//examples:simple_test_bazel_.bazelversion'
             runner: ubuntu-22.04
           - test: '@@//examples:simple_test_bazel_.bazelversion'
+            runner: macos-15
+          - test: '@@//examples:simple_test_bazel_last_green'
+            runner: ubuntu-22.04
+          - test: '@@//examples:simple_test_bazel_last_green'
             runner: macos-15
           - test: '@@//release:archive_test'
             runner: ubuntu-22.04

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,18 +51,11 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
-
-# GH0078: Disable last_green until
-# https://github.com/bazelbuild/continuous-integration/issues/2294 is addressed.
-# bazel_binaries.download(version = "last_green")
+bazel_binaries.download(version = "last_green")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-
-    # GH0078: Disable last_green until
-    # https://github.com/bazelbuild/continuous-integration/issues/2294 is
-    # addressed.
-    # "build_bazel_bazel_last_green",
+    "build_bazel_bazel_last_green",
 )

--- a/examples/custom_swift_proto_compiler/MODULE.bazel
+++ b/examples/custom_swift_proto_compiler/MODULE.bazel
@@ -14,6 +14,7 @@ local_path_override(
 bazel_dep(name = "rules_swift_package_manager", version = "0.47.2")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.27.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 
 # The apple_support bazel_dep must come before the rules_cc.
 # https://github.com/bazelbuild/apple_support#incompatible-toolchain-resolution

--- a/examples/custom_swift_proto_compiler/rules/BUILD.bazel
+++ b/examples/custom_swift_proto_compiler/rules/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 sh_binary(
     name = "custom_proto_compiler",


### PR DESCRIPTION
- Enable `last_green` builds.
- Add `rules_shell` to `custom_swift_proto_compiler` example.

Closes #78.