### PR TITLE
chore: upgrade rules_swift_package_manager to 1.0.0-rc3

### DIFF
--- a/bzlmod/workspace/MODULE.bazel
+++ b/bzlmod/workspace/MODULE.bazel
@@ -7,7 +7,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_swift_package_manager", version = "0.47.2")
+bazel_dep(name = "rules_swift_package_manager", version = "1.0.0-rc3")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.27.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 

--- a/examples/custom_swift_proto_compiler/MODULE.bazel
+++ b/examples/custom_swift_proto_compiler/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_swift_package_manager", version = "0.47.2")
+bazel_dep(name = "rules_swift_package_manager", version = "1.0.0-rc3")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.27.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_shell", version = "0.4.1")

--- a/examples/grpc_example/MODULE.bazel
+++ b/examples/grpc_example/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_swift_package_manager", version = "0.47.2")
+bazel_dep(name = "rules_swift_package_manager", version = "1.0.0-rc3")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.27.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 

--- a/examples/grpc_package_example/MODULE.bazel
+++ b/examples/grpc_package_example/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_swift_package_manager", version = "0.47.2")
+bazel_dep(name = "rules_swift_package_manager", version = "1.0.0-rc3")
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.27.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 


### PR DESCRIPTION
This version of `rules_swift_package_manager` contains a fix for `//:update_swift_packages` so that it runs properly on Linux.
