### PR TITLE
chore: run `//:update_swift_packages_for_modified` in `do_renovate_post_upgrade`

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -30,3 +30,5 @@ fi
 export CC=clang
 "${bazelisk}" run --action_env=PATH //:tidy_modified
 
+# Execute swift package update on modified workspaces.
+"${bazelisk}" run --action_env=PATH //:update_swift_packages_for_modified


### PR DESCRIPTION
This ensures that the `Package.resolved` files are updated if necessary.
