### PR TITLE
fix: correct bot detection in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false && !github.event.pull_request.user.bot
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.type != 'Bot'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
- Fix bot detection condition in Claude Code Review workflow from non-existent `user.bot` field to correct `user.type \!= 'Bot'` field
- Prevents workflow from running on bot-created PRs (like renovate PRs)

## Details
The workflow was incorrectly using `\!github.event.pull_request.user.bot` to detect bots, but this field doesn't exist in GitHub webhook payloads. The correct field is `user.type` which has values "User" or "Bot".

This fix ensures the Claude Code Review workflow only runs on PRs created by human users, not bots.

## Test plan
- [x] Verified the correct field name through GitHub webhook documentation
- [x] Updated the workflow condition to use `user.type \!= 'Bot'`
- [ ] Workflow should skip future bot-created PRs

🤖 Generated with [Claude Code](https://claude.ai/code)