### PR TITLE
chore: add .mergify.yml to enable merge queue again

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,27 @@
+queue_rules:
+  - name: default
+    batch_size: 1
+    merge_conditions:
+      - check-success=all_ci_tests
+      - check-success=conventional_commit_check
+    queue_conditions:
+      - check-success=all_ci_tests
+      - check-success=conventional_commit_check
+
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - check-success=all_ci_tests
+      - check-success=conventional_commit_check
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - -draft
+      - -closed
+      - -merged
+      - base=main
+    actions:
+      queue:
+        name: default
+
+merge_queue:
+  max_parallel_checks: 1


### PR DESCRIPTION
The Mergify merge queue stopped working recently. Adding this explicit config fixed this in `rules_swift_package_manager`.