### PR TITLE
fix(ci): correct workflow_dispatch input name in publish-to-bcr workflow

### DIFF
--- a/.github/workflows/publish_to_bcr.yml
+++ b/.github/workflows/publish_to_bcr.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
+      tag_name:
         description: "The release tag to publish (e.g. v1.2.3)"
         required: true
         type: string


### PR DESCRIPTION
The workflow_dispatch input was defined as 'tag' but referenced as 'inputs.tag_name', causing the publish-to-bcr workflow to receive a null value and fail with "Input required and not supplied: module-version".

Changed input name from 'tag' to 'tag_name' to match the reference.